### PR TITLE
Allow changing of properties mid-playback

### DIFF
--- a/UnityAdmProject/Assets/UnityAdm/Editor/UnityAdmEditor.cs
+++ b/UnityAdmProject/Assets/UnityAdm/Editor/UnityAdmEditor.cs
@@ -39,6 +39,10 @@ public class UnityAdmFunctions : EditorWindow
         {
             stopPlayback();
         }
+        if (GUILayout.Button("Apply new settings"))
+        {
+            apply();
+        }
         if (GUILayout.Button("Apply new settings and Reinitialise"))
         {
             reinit();
@@ -64,6 +68,14 @@ public class UnityAdmFunctions : EditorWindow
 
         var script = FindObjectOfType<UnityAdm>();
         script.stopPlayback();
+    }
+
+    private void apply()
+    {
+        if (!Application.isPlaying) return;
+
+        var script = FindObjectOfType<UnityAdm>();
+        script.applySettings();
     }
 
     private void reinit()

--- a/UnityAdmProject/Assets/UnityAdm/Scripts/AudioRenderingBear.cs
+++ b/UnityAdmProject/Assets/UnityAdm/Scripts/AudioRenderingBear.cs
@@ -34,6 +34,7 @@ namespace ADM
 
         private UInt64 itemId;
         public int blockSendCounter = 0;
+        public long lastSentBlockRevision = -1;
     }
 
     public class BearItemTracker
@@ -109,6 +110,16 @@ namespace ADM
         {
             orderedFilteredItems[index].blockSendCounter++;
             return orderedFilteredItems[index].blockSendCounter;
+        }
+
+        public void setLastSentBlockRevisionForIndex(int index, long revision)
+        {
+            orderedFilteredItems[index].lastSentBlockRevision = revision;
+        }
+
+        public long getLastSentBlockRevisionForIndex(int index)
+        {
+            return orderedFilteredItems[index].lastSentBlockRevision;
         }
 
         public void updateMappings()

--- a/UnityAdmProject/Assets/UnityAdm/Scripts/GlobalState.cs
+++ b/UnityAdmProject/Assets/UnityAdm/Scripts/GlobalState.cs
@@ -94,31 +94,143 @@ namespace ADM
         public static float BearOutputGain = 0.775f;
         public static SrcType BearSrcType = SrcType.SincMediumQuality;
 
-        // Offsetting
-        public static double directSpeakersXOffset = 0.0;
-        public static double directSpeakersYOffset = 0.0;
-        public static double directSpeakersZOffset = 0.0;
+        // Runtime-modifiable Properties
+        public static long propertiesRevisionCounter = 0;
+
+        /// Offsetting
+        private static double _directSpeakersXOffset = 0.0;
+        public static double directSpeakersXOffset
+        {
+            get { return _directSpeakersXOffset; }
+            set
+            {
+                _directSpeakersXOffset = value;
+                propertiesRevisionCounter++;
+            }
+        }
+        private static double _directSpeakersYOffset = 0.0;
+        public static double directSpeakersYOffset
+        {
+            get { return _directSpeakersYOffset; }
+            set
+            {
+                _directSpeakersYOffset = value;
+                propertiesRevisionCounter++;
+            }
+        }
+        private static double _directSpeakersZOffset = 0.0;
+        public static double directSpeakersZOffset
+        {
+            get { return _directSpeakersZOffset; }
+            set
+            {
+                _directSpeakersZOffset = value;
+                propertiesRevisionCounter++;
+            }
+        }
         public static bool applyDirectSpeakersCartOffset
         {
             get { return (directSpeakersXOffset != 0.0 || directSpeakersYOffset != 0.0 || directSpeakersZOffset != 0.0); }
         }
-        public static double directSpeakersAzimuthOffset = 0.0;
-        public static double directSpeakersElevationOffset = 0.0;
-        public static double directSpeakersDistanceMultiplier = 1.0;
+        private static double _directSpeakersAzimuthOffset = 0.0;
+        public static double directSpeakersAzimuthOffset
+        {
+            get { return _directSpeakersAzimuthOffset; }
+            set
+            {
+                _directSpeakersAzimuthOffset = value;
+                propertiesRevisionCounter++;
+            }
+        }
+        private static double _directSpeakersElevationOffset = 0.0;
+        public static double directSpeakersElevationOffset
+        {
+            get { return _directSpeakersElevationOffset; }
+            set
+            {
+                _directSpeakersElevationOffset = value;
+                propertiesRevisionCounter++;
+            }
+        }
+        private static double _directSpeakersDistanceMultiplier = 1.0;
+        public static double directSpeakersDistanceMultiplier
+        {
+            get { return _directSpeakersDistanceMultiplier; }
+            set
+            {
+                _directSpeakersDistanceMultiplier = value;
+                propertiesRevisionCounter++;
+            }
+        }
         public static bool applyDirectSpeakersSphOffset
         {
             get { return (directSpeakersAzimuthOffset != 0.0 || directSpeakersElevationOffset != 0.0 || directSpeakersDistanceMultiplier != 1.0); }
         }
-        public static double objectsXOffset = 0.0;
-        public static double objectsYOffset = 0.0;
-        public static double objectsZOffset = 0.0;
+
+        private static double _objectsXOffset = 0.0;
+        public static double objectsXOffset
+        {
+            get { return _objectsXOffset; }
+            set
+            {
+                _objectsXOffset = value;
+                propertiesRevisionCounter++;
+            }
+        }
+        private static double _objectsYOffset = 0.0;
+        public static double objectsYOffset
+        {
+            get { return _objectsYOffset; }
+            set
+            {
+                _objectsYOffset = value;
+                propertiesRevisionCounter++;
+            }
+        }
+        private static double _objectsZOffset = 0.0;
+        public static double objectsZOffset
+        {
+            get { return _objectsZOffset; }
+            set
+            {
+                _objectsZOffset = value;
+                propertiesRevisionCounter++;
+            }
+        }
         public static bool applyObjectsCartOffset
         {
             get { return (objectsXOffset != 0.0 || objectsYOffset != 0.0 || objectsZOffset != 0.0); }
         }
-        public static double objectsAzimuthOffset = 0.0;
-        public static double objectsElevationOffset = 0.0;
-        public static double objectsDistanceMultiplier = 1.0;
+        private static double _objectsAzimuthOffset = 0.0;
+        public static double objectsAzimuthOffset
+        {
+            get { return _objectsAzimuthOffset; }
+            set
+            {
+                _objectsAzimuthOffset = value;
+                propertiesRevisionCounter++;
+            }
+        }
+        private static double _objectsElevationOffset = 0.0;
+        public static double objectsElevationOffset
+        {
+            get { return _objectsElevationOffset; }
+            set
+            {
+                _objectsElevationOffset = value;
+                propertiesRevisionCounter++;
+            }
+        }
+        private static double _objectsDistanceMultiplier = 1.0;
+        public static double objectsDistanceMultiplier
+        {
+            get { return _objectsDistanceMultiplier; }
+            set
+            {
+                _objectsDistanceMultiplier = value;
+                propertiesRevisionCounter++;
+            }
+        }
         public static bool applyObjectsSphOffset
         {
             get { return (objectsAzimuthOffset != 0.0 || objectsElevationOffset != 0.0 || objectsDistanceMultiplier != 1.0); }

--- a/UnityAdmProject/Assets/UnityAdm/Scripts/UnityAdmFilterComponent.cs
+++ b/UnityAdmProject/Assets/UnityAdm/Scripts/UnityAdmFilterComponent.cs
@@ -187,12 +187,27 @@ namespace ADM
                         int blockNum = bear.bearObjects.getBlockSendCounterAtIndex(index);
                         int blockNumLimit = GlobalState.metadataHandler.renderableItems[id].blocks.Count;
 
+                        if (blockNum > 0)
+                        {
+                            // Ensure last block we sent has not gone stale in meantime
+                            GlobalState.metadataHandler.renderableItems[id].blocks[blockNum - 1].processMetadataBlockIfNecessary();
+                            long targetRevision = GlobalState.metadataHandler.renderableItems[id].blocks[blockNum - 1].metadataBlockProcessedRevision;
+                            if (bear.bearObjects.getLastSentBlockRevisionForIndex(index) < targetRevision)
+                            {
+                                // Last sent block has since changed (due to script properties change) - resend
+                                LibraryInterface.addBearObjectMetadata(index, ref GlobalState.metadataHandler.renderableItems[id].blocks[blockNum - 1].metadataBlockProcessed);
+                                bear.bearObjects.setLastSentBlockRevisionForIndex(index, targetRevision);
+                            }
+                        }
+
                         while (blockNum < blockNumLimit)
                         {
-                            if (!LibraryInterface.addBearObjectMetadata(index, ref GlobalState.metadataHandler.renderableItems[id].blocks[blockNum].metadataBlock))
+                            GlobalState.metadataHandler.renderableItems[id].blocks[blockNum].processMetadataBlockIfNecessary(); // Because we are accessing by ref, we can't use getter to ensure up to date.
+                            if (!LibraryInterface.addBearObjectMetadata(index, ref GlobalState.metadataHandler.renderableItems[id].blocks[blockNum].metadataBlockProcessed))
                             {
                                 break;
                             }
+                            bear.bearObjects.setLastSentBlockRevisionForIndex(index, GlobalState.metadataHandler.renderableItems[id].blocks[blockNum].metadataBlockProcessedRevision);
                             blockNum = bear.bearObjects.incBlockSendCounterAtIndex(index);
                         }
                     }
@@ -206,12 +221,27 @@ namespace ADM
                         int blockNum = bear.bearDirectSpeakers.getBlockSendCounterAtIndex(index);
                         int blockNumLimit = GlobalState.metadataHandler.renderableItems[id].blocks.Count;
 
+                        if (blockNum > 0)
+                        {
+                            // Ensure last block we sent has not gone stale in meantime
+                            GlobalState.metadataHandler.renderableItems[id].blocks[blockNum - 1].processMetadataBlockIfNecessary();
+                            long targetRevision = GlobalState.metadataHandler.renderableItems[id].blocks[blockNum - 1].metadataBlockProcessedRevision;
+                            if (bear.bearDirectSpeakers.getLastSentBlockRevisionForIndex(index) < targetRevision)
+                            {
+                                // Last sent block has since changed (due to script properties change) - resend
+                                LibraryInterface.addBearObjectMetadata(index, ref GlobalState.metadataHandler.renderableItems[id].blocks[blockNum - 1].metadataBlockProcessed);
+                                bear.bearDirectSpeakers.setLastSentBlockRevisionForIndex(index, targetRevision);
+                            }
+                        }
+
                         while (blockNum < blockNumLimit)
                         {
-                            if (!LibraryInterface.addBearDirectSpeakersMetadata(index, ref GlobalState.metadataHandler.renderableItems[id].blocks[blockNum].metadataBlock))
+                            GlobalState.metadataHandler.renderableItems[id].blocks[blockNum].processMetadataBlockIfNecessary(); // Because we are accessing by ref, we can't use getter to ensure up to date.
+                            if (!LibraryInterface.addBearDirectSpeakersMetadata(index, ref GlobalState.metadataHandler.renderableItems[id].blocks[blockNum].metadataBlockProcessed))
                             {
                                 break;
                             }
+                            bear.bearDirectSpeakers.setLastSentBlockRevisionForIndex(index, GlobalState.metadataHandler.renderableItems[id].blocks[blockNum].metadataBlockProcessedRevision);
                             blockNum = bear.bearDirectSpeakers.incBlockSendCounterAtIndex(index);
                         }
                     }
@@ -225,12 +255,27 @@ namespace ADM
                         int blockNum = bear.bearHoa.getBlockSendCounterAtIndex(index);
                         int blockNumLimit = GlobalState.metadataHandler.renderableItems[id].blocks.Count;
 
+                        if (blockNum > 0)
+                        {
+                            // Ensure last block we sent has not gone stale in meantime
+                            GlobalState.metadataHandler.renderableItems[id].blocks[blockNum - 1].processMetadataBlockIfNecessary();
+                            long targetRevision = GlobalState.metadataHandler.renderableItems[id].blocks[blockNum - 1].metadataBlockProcessedRevision;
+                            if (bear.bearHoa.getLastSentBlockRevisionForIndex(index) < targetRevision)
+                            {
+                                // Last sent block has since changed (due to script properties change) - resend
+                                LibraryInterface.addBearObjectMetadata(index, ref GlobalState.metadataHandler.renderableItems[id].blocks[blockNum - 1].metadataBlockProcessed);
+                                bear.bearHoa.setLastSentBlockRevisionForIndex(index, targetRevision);
+                            }
+                        }
+
                         while (blockNum < blockNumLimit)
                         {
-                            if (!LibraryInterface.addBearHoaMetadata(bear.bearHoa.getChannelIndicesForIndex(index), ref GlobalState.metadataHandler.renderableItems[id].blocks[blockNum].metadataBlock))
+                            GlobalState.metadataHandler.renderableItems[id].blocks[blockNum].processMetadataBlockIfNecessary(); // Because we are accessing by ref, we can't use getter to ensure up to date.
+                            if (!LibraryInterface.addBearHoaMetadata(bear.bearHoa.getChannelIndicesForIndex(index), ref GlobalState.metadataHandler.renderableItems[id].blocks[blockNum].metadataBlockProcessed))
                             {
                                 break;
                             }
+                            bear.bearHoa.setLastSentBlockRevisionForIndex(index, GlobalState.metadataHandler.renderableItems[id].blocks[blockNum].metadataBlockProcessedRevision);
                             blockNum = bear.bearHoa.incBlockSendCounterAtIndex(index);
                         }
                     }

--- a/UnityAdmProject/Assets/UnityAdm/UnityAdm.cs
+++ b/UnityAdmProject/Assets/UnityAdm/UnityAdm.cs
@@ -277,6 +277,20 @@ public class UnityAdm : MonoBehaviour
         while (objectsElevationOffset > 90.0) objectsElevationOffset = 90.0;
         while (objectsElevationOffset < -90.0) objectsElevationOffset = -90.0;
         if (objectsDistanceMultiplier < 0.0) objectsDistanceMultiplier = 0.0;
+
+        GlobalState.directSpeakersXOffset = directSpeakersUnityXOffset;
+        GlobalState.directSpeakersYOffset = directSpeakersUnityZOffset; // NOTE Y/Z SWITCH (Unity vs ADM)
+        GlobalState.directSpeakersZOffset = directSpeakersUnityYOffset; // NOTE Y/Z SWITCH (Unity vs ADM)
+        GlobalState.directSpeakersAzimuthOffset = directSpeakersAzimuthOffset;
+        GlobalState.directSpeakersElevationOffset = directSpeakersElevationOffset;
+        GlobalState.directSpeakersDistanceMultiplier = directSpeakersDistanceMultiplier;
+        GlobalState.objectsXOffset = objectsUnityXOffset;
+        GlobalState.objectsYOffset = objectsUnityZOffset; // NOTE Y/Z SWITCH (Unity vs ADM)
+        GlobalState.objectsZOffset = objectsUnityYOffset; // NOTE Y/Z SWITCH (Unity vs ADM)
+        GlobalState.objectsAzimuthOffset = objectsAzimuthOffset;
+        GlobalState.objectsElevationOffset = objectsElevationOffset;
+        GlobalState.objectsDistanceMultiplier = objectsDistanceMultiplier;
+
     }
 
 	public void recentreListener()


### PR DESCRIPTION
This was implemented for the offsetting controls, but the same mechanism can be used for other properties too.

The conversion/completion of metadata pulled from the native library is influenced by property values. We used to do this as soon as we received new metadata. Now the conversion is only done when it is required by another component (e.g, the BEAR renderer, or the dispatchLatestMetadata system). 

However, since we can request this from multiple places (or in fact multiple times from the same component, as the BEAR renderer will do if the native library rejects the metadata), it doesn't make sense to convert it on every request - we should cache it. The issue then becomes if the properties which influence the conversion are modified in the meantime. To determine if the converted metadata is up-to-date, we version the property set, and store this version when we convert the metadata. This way we can compare the stored version with the version of the current property set to see if there is a mismatch, and reconvert the metadata if necessary.